### PR TITLE
Add multiple tests for night actions

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -28,6 +28,9 @@ jobs:
           java-version: 21
           distribution: 'temurin'
 
+      - name: Run unit tests
+        run: ./gradlew test
+
       - name: Decode Keystore
         run: |
           echo "${{ secrets.SIGNING_KEYSTORE_BASE64 }}" | base64 -d > keystore.jks

--- a/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/GameEngine.kt
+++ b/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/GameEngine.kt
@@ -228,16 +228,20 @@ class GameEngine(
         _currentPhase.update { Phase.LastCard(player) }
     }
 
-    private fun proceedToNightPhase() {
-        val allPlayers = _players.value
-        val currentNight = currentDay.value
-
-        val godfatherReplacement = allPlayers
+    fun getGodFatherReplacement() = players.value.let { allPlayers ->
+        allPlayers
             .filter { it.role.alignment == Alignment.Mafia && it.isInGame }
             .minByOrNull { it.role.executionOrder }
             ?.takeIf {
                 allPlayers.none { p -> p.role.key == RoleKeys.GOD_FATHER && p.isInGame }
             }?.copy(role = GodFather)
+    }
+
+    private fun proceedToNightPhase() {
+        val allPlayers = _players.value
+        val currentNight = currentDay.value
+
+        val godfatherReplacement = getGodFatherReplacement()
 
         val playersForNight = if (godfatherReplacement != null)
             allPlayers + godfatherReplacement else allPlayers

--- a/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/actions/role/Actions.kt
+++ b/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/actions/role/Actions.kt
@@ -89,7 +89,7 @@ data object ShootAction : RoleAction {
             }
 
             Alignment.Civilian -> updatePlayer(updatedPlayers, shooter.id) {
-                copy(isAlive = false, currentHealthPoints = 1)
+                copy(isAlive = false, currentHealthPoints = 0)
             }
 
             Alignment.Neutral -> updatedPlayers

--- a/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/models/NightAction.kt
+++ b/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/models/NightAction.kt
@@ -5,7 +5,7 @@ import ir.amirroid.mafiauto.game.engine.role.Role
 data class NightAction(
     val player: Player,
     val targets: List<Player>,
-    val replacementRole: Role?
+    val replacementRole: Role? = null
 )
 
 

--- a/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/models/Player.kt
+++ b/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/models/Player.kt
@@ -21,3 +21,4 @@ data class Player(
 
 
 fun List<Player>.findWithId(id: Long) = find { it.id == id }
+fun List<Player>.findWithRoleKey(role: String) = find { it.role.key == role }

--- a/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/utils/NightActionOrder.kt
+++ b/game/engine/src/commonMain/kotlin/ir/amirroid/mafiauto/game/engine/utils/NightActionOrder.kt
@@ -14,22 +14,26 @@ val NightActionOrder: Map<String, Int> = mapOf(
     RoleKeys.SNIPER to 10,
     RoleKeys.RANGER to 11,
     RoleKeys.BULLETPROOF to 12,
-    RoleKeys.MAYOR to 13
+    RoleKeys.MAYOR to 13,
+    RoleKeys.CIVILIAN to 14,
+    RoleKeys.JOKER to 15
 )
 
 val SubmitNightActionOrder: Map<String, Int> = mapOf(
     RoleKeys.GOD_FATHER to 0,
     RoleKeys.SAUL_GOODMAN to 1,
-    RoleKeys.SNIPER to 2,
-    RoleKeys.SILENCER to 3,
-    RoleKeys.GUNSMITH to 4,
-    RoleKeys.MAFIA to 5,
-    RoleKeys.BOMBER to 6,
-    RoleKeys.DOCTOR to 7,
+    RoleKeys.SILENCER to 2,
+    RoleKeys.GUNSMITH to 3,
+    RoleKeys.MAFIA to 4,
+    RoleKeys.BOMBER to 5,
+    RoleKeys.DOCTOR to 6,
+    RoleKeys.SNIPER to 7,
     RoleKeys.DETECTIVE to 8,
     RoleKeys.NOSTRADAMUS to 9,
     RoleKeys.SURGEON to 10,
     RoleKeys.RANGER to 11,
     RoleKeys.BULLETPROOF to 12,
-    RoleKeys.MAYOR to 13
+    RoleKeys.MAYOR to 13,
+    RoleKeys.CIVILIAN to 14,
+    RoleKeys.JOKER to 15
 )

--- a/game/engine/src/commonTest/kotlin/ir/amirroid/mafiauto/engine/test/NightActionsTest.kt
+++ b/game/engine/src/commonTest/kotlin/ir/amirroid/mafiauto/engine/test/NightActionsTest.kt
@@ -1,0 +1,251 @@
+package ir.amirroid.mafiauto.engine.test
+
+import ir.amirroid.mafiauto.engine.base.GameEngineTestBase
+import ir.amirroid.mafiauto.game.engine.effect.GunShotDayActionEffect
+import ir.amirroid.mafiauto.game.engine.models.NightAction
+import ir.amirroid.mafiauto.game.engine.models.Phase
+import ir.amirroid.mafiauto.game.engine.models.findWithRoleKey
+import ir.amirroid.mafiauto.game.engine.role.GodFather
+import ir.amirroid.mafiauto.game.engine.utils.RoleKeys
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class NightActionsTest : GameEngineTestBase() {
+    @Test
+    fun shouldEnterNightPhaseAndHandleEmptyActions() {
+        advanceToNightPhase()
+        engine.handleNightActions(emptyList())
+        assertIs<Phase.Result>(engine.currentPhase.value)
+    }
+
+    @Test
+    fun doctorShouldSuccessfullySaveTargetFromMafiaAttack() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.GOD_FATHER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!)
+            ),
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.DOCTOR)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!)
+            ),
+        )
+        engine.handleNightActions(actions)
+        assertTrue(players.findWithRoleKey(RoleKeys.MAYOR)!!.isAlive)
+    }
+
+    @Test
+    fun doctorShouldFailToSaveIfHealingWrongTarget() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.GOD_FATHER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!)
+            ),
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.DOCTOR)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.SILENCER)!!)
+            ),
+        )
+        engine.handleNightActions(actions)
+        assertFalse(players.findWithRoleKey(RoleKeys.MAYOR)!!.isAlive)
+    }
+
+    @Test
+    fun sniperShouldFailToKillGodFatherOnFirstAttemptButSucceedNextTime() {
+        advanceToNightPhase()
+        fun getActions() = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.SNIPER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.GOD_FATHER)!!)
+            ),
+        )
+        engine.handleNightActions(getActions())
+        assertTrue(players.findWithRoleKey(RoleKeys.GOD_FATHER)!!.isAlive)
+        advanceToNightPhase()
+        engine.handleNightActions(getActions())
+        assertFalse(players.findWithRoleKey(RoleKeys.GOD_FATHER)!!.isAlive)
+    }
+
+
+    @Test
+    fun sniperDiesIfTargetsCivilian() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.SNIPER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!)
+            )
+        )
+        engine.handleNightActions(actions)
+        assertTrue(players.findWithRoleKey(RoleKeys.MAYOR)!!.isAlive)
+        assertFalse(players.findWithRoleKey(RoleKeys.SNIPER)!!.isAlive)
+    }
+
+
+    @Test
+    fun silencerShouldSilenceTarget() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.SILENCER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!)
+            )
+        )
+        engine.handleNightActions(actions)
+        assertTrue(players.findWithRoleKey(RoleKeys.MAYOR)!!.isSilenced)
+    }
+
+    @Test
+    fun replacementGodFatherShouldKillTarget() {
+        sniperShouldFailToKillGodFatherOnFirstAttemptButSucceedNextTime()
+        advanceToNightPhase()
+        val replacementGodFather = engine.getGodFatherReplacement()
+        assertNotNull(replacementGodFather)
+        val actions = listOf(
+            NightAction(
+                player = replacementGodFather,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!),
+                replacementRole = GodFather
+            )
+        )
+        engine.handleNightActions(actions)
+        assertFalse(players.findWithRoleKey(RoleKeys.MAYOR)!!.isAlive)
+    }
+
+    @Test
+    fun replacementGodFatherShouldAppearInNightPhaseOptions() {
+        sniperShouldFailToKillGodFatherOnFirstAttemptButSucceedNextTime()
+        val phase = advanceToNightPhase()
+        assertTrue { phase.options.any { it.isReplacement && it.player.role == GodFather } }
+    }
+
+    @Test
+    fun rangerShouldKillTargetButDieIfTargetsMayor() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.RANGER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.SURGEON)!!)
+            )
+        )
+        engine.handleNightActions(actions)
+        assertTrue(players.findWithRoleKey(RoleKeys.RANGER)!!.isAlive)
+        assertFalse(players.findWithRoleKey(RoleKeys.SURGEON)!!.isAlive)
+        val actions2 = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.RANGER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.MAYOR)!!)
+            )
+        )
+        engine.handleNightActions(actions2)
+        assertFalse(players.findWithRoleKey(RoleKeys.RANGER)!!.isAlive)
+        assertTrue(players.findWithRoleKey(RoleKeys.MAYOR)!!.isAlive)
+    }
+
+    @Test
+    fun mayorShouldReceiveMessageWithSurgeonAndDoctorNames() {
+        val phase = advanceToNightPhase()
+
+        val mayorOption = phase.options.firstOrNull {
+            it.player.role.key == RoleKeys.MAYOR
+        }
+        assertNotNull(mayorOption)
+
+        val mayorMessage = mayorOption.message
+        assertNotNull(mayorMessage)
+
+        val expectedPlayers = listOf(
+            players.findWithRoleKey(RoleKeys.SURGEON)!!.name,
+            players.findWithRoleKey(RoleKeys.DOCTOR)!!.name,
+        )
+
+        val allNamesPresent = mayorMessage.formatArgs.all { it in expectedPlayers }
+        assertTrue(allNamesPresent)
+    }
+
+    @Test
+    fun bomberExplosionShouldKillNeighbors() {
+        advanceToNightPhase()
+        val bomber = players.findWithRoleKey(RoleKeys.BOMBER)!!
+        val bomberIndex = players.indexOf(bomber)
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.GOD_FATHER)!!,
+                targets = listOf(bomber)
+            )
+        )
+        engine.handleNightActions(actions)
+        assertFalse(players[bomberIndex - 1].isAlive)
+        assertFalse(players[bomberIndex + 1].isAlive)
+    }
+
+    @Test
+    fun bulletproofPlayerShouldSurviveGodFatherAttack() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.GOD_FATHER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.BULLETPROOF)!!)
+            )
+        )
+        engine.handleNightActions(actions)
+        assertTrue(players.findWithRoleKey(RoleKeys.BULLETPROOF)!!.isAlive)
+    }
+
+    @Test
+    fun realAndPracticeShotsShouldKillCorrectTargets() {
+        advanceToNightPhase()
+        val gunSmith = players.findWithRoleKey(RoleKeys.GUNSMITH)!!
+        val bulletProof = players.findWithRoleKey(RoleKeys.BULLETPROOF)!!
+        val mayor = players.findWithRoleKey(RoleKeys.MAYOR)!!
+        val doctor = players.findWithRoleKey(RoleKeys.DOCTOR)!!
+        val sniper = players.findWithRoleKey(RoleKeys.SNIPER)!!
+
+        engine.handleNightActions(listOf(NightAction(gunSmith, listOf(bulletProof, mayor))))
+
+        val updatedBulletProof = players.findWithRoleKey(RoleKeys.BULLETPROOF)!!
+        val updatedMayor = players.findWithRoleKey(RoleKeys.MAYOR)!!
+
+        val bulletProofEffect =
+            updatedBulletProof.effects.filterIsInstance<GunShotDayActionEffect>().first()
+        val mayorEffect = updatedMayor.effects.filterIsInstance<GunShotDayActionEffect>().first()
+
+        bulletProofEffect.getAction()
+            .applyAction(updatedBulletProof, listOf(doctor), players, engine)
+        mayorEffect.getAction().applyAction(updatedMayor, listOf(sniper), players, engine)
+
+        assertFalse(players.findWithRoleKey(RoleKeys.DOCTOR)!!.isAlive)
+        assertTrue(players.findWithRoleKey(RoleKeys.SNIPER)!!.isAlive)
+    }
+
+    @Test
+    fun sniperShotFailsButSurgeonSavesMafia() {
+        advanceToNightPhase()
+        val actions = listOf(
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.SNIPER)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.SAUL_GOODMAN)!!)
+            ),
+            NightAction(
+                player = players.findWithRoleKey(RoleKeys.SURGEON)!!,
+                targets = listOf(players.findWithRoleKey(RoleKeys.SAUL_GOODMAN)!!)
+            ),
+        )
+        engine.handleNightActions(actions)
+        assertTrue(players.findWithRoleKey(RoleKeys.SAUL_GOODMAN)!!.isAlive)
+    }
+
+
+    private fun advanceToNightPhase(): Phase.Night {
+        engine.proceedToNextPhase() // Day → Voting
+        engine.proceedToDefendingPhase(emptyList()) // Voting → Defending
+        engine.proceedToNextPhase() // Defending → Night
+        assertIs<Phase.Night>(engine.currentPhase.value)
+        return engine.currentPhase.value as Phase.Night
+    }
+}


### PR DESCRIPTION
This PR adds multiple unit tests for the night actions logic in the game engine. The new tests focus on verifying the interactions and effects of different roles’ night actions.

You can run the tests with:

```bash
./gradlew test
```
