### PR TITLE
Add wasm js support [WIP]

### DIFF
--- a/build-logic/convention/src/main/kotlin/ir/amirroid/mafiauto/convention/kotlin/KotlinMultiplatformConfiguration.kt
+++ b/build-logic/convention/src/main/kotlin/ir/amirroid/mafiauto/convention/kotlin/KotlinMultiplatformConfiguration.kt
@@ -17,6 +17,14 @@ internal fun Project.configureKotlinMultiplatformPlugins(extensions: KotlinMulti
         androidTarget()
         configureIosTargets()
         jvm("desktop")
+        wasmJs {
+            browser {
+                commonWebpackConfig {
+                    outputFileName = "composeApp.js"
+                }
+            }
+            binaries.executable()
+        }
 
         configureCommonMain(sourceSets)
         configureAndroidMain(sourceSets)

--- a/build-logic/convention/src/main/kotlin/ir/amirroid/mafiauto/convention/kotlin/KotlinMultiplatformConfiguration.kt
+++ b/build-logic/convention/src/main/kotlin/ir/amirroid/mafiauto/convention/kotlin/KotlinMultiplatformConfiguration.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 @OptIn(ExperimentalWasmDsl::class)
 internal fun Project.configureKotlinMultiplatformPlugins(extensions: KotlinMultiplatformExtension) {

--- a/composeApp/src/commonMain/kotlin/ir/amirroid/mafiauto/App.kt
+++ b/composeApp/src/commonMain/kotlin/ir/amirroid/mafiauto/App.kt
@@ -24,9 +24,17 @@ import ir.amirroid.mafiauto.ui_models.settings.SettingsUiModel
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun App() {
+fun App(
+    onConfigurationChange: ((SettingsUiModel) -> Unit)? = null
+) {
     val viewModel: AppViewModel = koinViewModel()
     val configuration by viewModel.settingsConfiguration.collectAsStateWithLifecycle()
+
+    onConfigurationChange?.let { callback ->
+        LaunchedEffect(configuration) {
+            configuration?.let(callback)
+        }
+    }
 
     if (configuration == null) {
         LoadingContent()

--- a/composeApp/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/main.kt
@@ -1,0 +1,62 @@
+package ir.amirroid.mafiauto
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.ComposeViewport
+import ir.amirroid.mafiauto.common.compose.modifiers.thenIf
+import ir.amirroid.mafiauto.di.DependencyInjectionConfiguration
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.w3c.dom.events.Event
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    DependencyInjectionConfiguration.configure { modules(projectModule) }
+
+    ComposeViewport(document.body ?: return) {
+        ResponsiveBox { App() }
+    }
+}
+
+
+@Composable
+fun ResponsiveBox(content: @Composable () -> Unit) {
+    var windowWidth by remember { mutableStateOf(window.innerWidth) }
+    val isLargeMonitor = windowWidth > 768
+
+    DisposableEffect(Unit) {
+        val resizeListener: (Event) -> Unit = {
+            windowWidth = window.innerWidth
+        }
+        window.addEventListener("resize", resizeListener)
+        onDispose {
+            window.removeEventListener("resize", resizeListener)
+        }
+    }
+
+    Box(Modifier.fillMaxSize().background(Color.Black), contentAlignment = Alignment.Center) {
+        Box(
+            Modifier.thenIf(isLargeMonitor) {
+                clip(RoundedCornerShape(8.dp))
+                    .fillMaxHeight(.95f)
+                    .aspectRatio(9 / 16f)
+            }
+        ) { content.invoke() }
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/main.kt
+++ b/composeApp/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/main.kt
@@ -30,7 +30,9 @@ fun main() {
     DependencyInjectionConfiguration.configure { modules(projectModule) }
 
     ComposeViewport(document.body ?: return) {
-        ResponsiveBox { App() }
+        ResponsiveBox {
+            App()
+        }
     }
 }
 

--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mafiauto</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/composeApp/src/wasmJsMain/resources/index.html
+++ b/composeApp/src/wasmJsMain/resources/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mafiauto</title>
     <link type="text/css" rel="stylesheet" href="styles.css">
+    <link id="favicon" rel="shortcut icon" type="image/png" href="logo_red.jpg"/>
     <script type="application/javascript" src="composeApp.js"></script>
 </head>
 <body>

--- a/composeApp/src/wasmJsMain/resources/styles.css
+++ b/composeApp/src/wasmJsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}

--- a/core/common/compose/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/common/compose/components/PlatformBackHandler.wasmJs.kt
+++ b/core/common/compose/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/common/compose/components/PlatformBackHandler.wasmJs.kt
@@ -1,0 +1,8 @@
+package ir.amirroid.mafiauto.common.compose.components
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun PlatformBackHandler(handle: () -> Unit) {
+    // no-op
+}

--- a/core/common/compose/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/common/compose/utils/LocaleUtils.wasmJs.kt
+++ b/core/common/compose/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/common/compose/utils/LocaleUtils.wasmJs.kt
@@ -1,0 +1,11 @@
+package ir.amirroid.mafiauto.common.compose.utils
+
+
+actual object LocaleUtils {
+    actual fun getDefaultLanguage(): String {
+        return "en"
+    }
+
+    actual fun setDefaultLanguage(language: String) {
+    }
+}

--- a/core/common/compose/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/common/compose/utils/PlatformCapabilities.wasmJs.kt
+++ b/core/common/compose/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/common/compose/utils/PlatformCapabilities.wasmJs.kt
@@ -1,0 +1,5 @@
+package ir.amirroid.mafiauto.common.compose.utils
+
+actual object PlatformCapabilities {
+    actual val blurSupported: Boolean = true
+}

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
     sourceSets.wasmJsMain.dependencies {
         implementation("app.cash.sqldelight:web-worker-driver:2.1.0")
         implementation(devNpm("copy-webpack-plugin", "9.1.0"))
+        implementation(npm("@cashapp/sqldelight-sqljs-worker", "2.1.0"))
+        implementation(npm("sql.js", "1.8.0"))
     }
 }
 
@@ -38,6 +40,7 @@ sqldelight {
                 file("src/commonMain/sqldelight/${AppInfo.namespace.replace('.', '/')}")
             )
             verifyMigrations.set(true)
+            generateAsync.set(true)
             deriveSchemaFromMigrations.set(true)
         }
     }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -23,6 +23,10 @@ kotlin {
     sourceSets.desktopMain.dependencies {
         implementation(libs.sqlite.driver)
     }
+    sourceSets.wasmJsMain.dependencies {
+        implementation("app.cash.sqldelight:web-worker-driver:2.1.0")
+        implementation(devNpm("copy-webpack-plugin", "9.1.0"))
+    }
 }
 
 sqldelight {

--- a/core/database/src/androidMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.android.kt
+++ b/core/database/src/androidMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.android.kt
@@ -1,6 +1,7 @@
 package ir.amirroid.mafiauto.database.di
 
 import androidx.sqlite.db.SupportSQLiteDatabase
+import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import ir.amirroid.mafiauto.AppDatabase
@@ -10,13 +11,12 @@ import org.koin.core.module.Module
 
 actual fun Module.configureDriver() {
     single<SqlDriver> {
+        val synchronousScheme = AppDatabase.Schema.synchronous()
         AndroidSqliteDriver(
-            schema = AppDatabase.Schema,
+            schema = synchronousScheme,
             context = androidContext(),
             name = DB_NAME,
-            callback = object : AndroidSqliteDriver.Callback(
-                AppDatabase.Schema
-            ) {
+            callback = object : AndroidSqliteDriver.Callback(synchronousScheme) {
                 override fun onConfigure(db: SupportSQLiteDatabase) {
                     super.onConfigure(db)
                     db.execSQL("PRAGMA foreign_keys=ON;")

--- a/core/database/src/commonMain/kotlin/ir/amirroid/mafiauto/database/Extensions.kt
+++ b/core/database/src/commonMain/kotlin/ir/amirroid/mafiauto/database/Extensions.kt
@@ -1,0 +1,7 @@
+package ir.amirroid.mafiauto.database
+
+import app.cash.sqldelight.db.SqlDriver
+
+fun SqlDriver.enableForeignKeys() {
+    execute(null, "PRAGMA foreign_keys = ON;", 0)
+}

--- a/core/database/src/commonMain/kotlin/ir/amirroid/mafiauto/database/dao/group/GroupDaoImpl.kt
+++ b/core/database/src/commonMain/kotlin/ir/amirroid/mafiauto/database/dao/group/GroupDaoImpl.kt
@@ -36,15 +36,15 @@ class GroupDaoImpl(
     }
 
     override suspend fun addNewGroup(name: String) {
-        queries.addNewGroup(name).await()
+        queries.addNewGroup(name)
     }
 
     override suspend fun editGroupName(groupId: Long, newName: String) {
-        queries.updateGroupName(newName, groupId).await()
+        queries.updateGroupName(newName, groupId)
     }
 
     override suspend fun deleteGroup(groupId: Long) {
-        queries.deleteGroupById(groupId).await()
+        queries.deleteGroupById(groupId)
     }
 
     override suspend fun updateGroupPinState(groupId: Long, isPinned: Boolean) {

--- a/core/database/src/commonMain/kotlin/ir/amirroid/mafiauto/database/dao/player/PlayerDaoImpl.kt
+++ b/core/database/src/commonMain/kotlin/ir/amirroid/mafiauto/database/dao/player/PlayerDaoImpl.kt
@@ -22,10 +22,10 @@ class PlayerDaoImpl(
     }
 
     override suspend fun addPlayer(name: String, groupId: Long) {
-        queries.addPlayer(name, groupId).await()
+        queries.addPlayer(name, groupId)
     }
 
     override suspend fun deletePlayer(id: Long) {
-        queries.deletePlayer(id).await()
+        queries.deletePlayer(id)
     }
 }

--- a/core/database/src/desktopMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.desktop.kt
+++ b/core/database/src/desktopMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.desktop.kt
@@ -1,22 +1,22 @@
 package ir.amirroid.mafiauto.database.di
 
+import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import ir.amirroid.mafiauto.AppDatabase
 import ir.amirroid.mafiauto.database.DB_NAME
+import ir.amirroid.mafiauto.database.enableForeignKeys
 import org.koin.core.module.Module
 
 actual fun Module.configureDriver() {
     single<SqlDriver> {
         val dbPath = "$DB_NAME.db"
-        val file = java.io.File(dbPath)
 
-        val driver = JdbcSqliteDriver("jdbc:sqlite:$dbPath")
-
-        if (!file.exists()) {
-            AppDatabase.Schema.create(driver)
+        JdbcSqliteDriver(
+            "jdbc:sqlite:$dbPath",
+            schema = AppDatabase.Schema.synchronous()
+        ).apply {
+            enableForeignKeys()
         }
-
-        driver
     }
 }

--- a/core/database/src/iosMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.ios.kt
+++ b/core/database/src/iosMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.ios.kt
@@ -1,18 +1,20 @@
 package ir.amirroid.mafiauto.database.di
 
+import app.cash.sqldelight.async.coroutines.synchronous
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import ir.amirroid.mafiauto.AppDatabase
 import ir.amirroid.mafiauto.database.DB_NAME
+import ir.amirroid.mafiauto.database.enableForeignKeys
 import org.koin.core.module.Module
 
 actual fun Module.configureDriver() {
     single<SqlDriver> {
         NativeSqliteDriver(
-            schema = AppDatabase.Schema,
+            schema = AppDatabase.Schema.synchronous(),
             name = DB_NAME,
         ).apply {
-            execute(null, "PRAGMA foreign_keys=ON;", 0)
+            enableForeignKeys()
         }
     }
 }

--- a/core/database/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.wasmJs.kt
+++ b/core/database/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.wasmJs.kt
@@ -1,0 +1,18 @@
+package ir.amirroid.mafiauto.database.di
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.worker.WebWorkerDriver
+import ir.amirroid.mafiauto.AppDatabase
+import org.koin.core.module.Module
+import org.w3c.dom.Worker
+
+
+actual fun Module.configureDriver() {
+    single<SqlDriver> {
+        val driver = WebWorkerDriver(
+            Worker("""new URL("@cashapp/sqldelight-sqljs-worker/sqljs.worker.js", import.meta.url)""")
+        )
+        runCatching { AppDatabase.Schema.create(driver) }
+        driver
+    }
+}

--- a/core/database/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.wasmJs.kt
+++ b/core/database/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/database/di/DatabaseModule.wasmJs.kt
@@ -2,17 +2,19 @@ package ir.amirroid.mafiauto.database.di
 
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.worker.WebWorkerDriver
-import ir.amirroid.mafiauto.AppDatabase
+import ir.amirroid.mafiauto.database.enableForeignKeys
 import org.koin.core.module.Module
 import org.w3c.dom.Worker
 
 
+private val workerScriptUrl: String =
+    js("""new URL("@cashapp/sqldelight-sqljs-worker/sqljs.worker.js", import.meta.url)""")
+
+
 actual fun Module.configureDriver() {
     single<SqlDriver> {
-        val driver = WebWorkerDriver(
-            Worker("""new URL("@cashapp/sqldelight-sqljs-worker/sqljs.worker.js", import.meta.url)""")
-        )
-        runCatching { AppDatabase.Schema.create(driver) }
-        driver
+        WebWorkerDriver(Worker(workerScriptUrl)).apply {
+            enableForeignKeys()
+        }
     }
 }

--- a/core/design-system/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/design_system/components/popup/PlatformPopup.wasmJs.kt
+++ b/core/design-system/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/design_system/components/popup/PlatformPopup.wasmJs.kt
@@ -1,0 +1,28 @@
+package ir.amirroid.mafiauto.design_system.components.popup
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+internal actual fun PlatformPopup(
+    onDismissRequest: () -> Unit,
+    dismissOnBackPress: Boolean,
+    dismissOnClickOutside: Boolean,
+    content: @Composable (() -> Unit)
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            dismissOnBackPress = dismissOnBackPress,
+            dismissOnClickOutside = dismissOnClickOutside,
+            scrimColor = Color.Transparent,
+            usePlatformInsets = false
+        ),
+        content = content
+    )
+}

--- a/core/di/src/androidMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.android.kt
+++ b/core/di/src/androidMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.android.kt
@@ -1,0 +1,5 @@
+package ir.amirroid.mafiauto.di.modules
+
+import kotlinx.coroutines.Dispatchers
+
+actual fun getIoDispatcher() = Dispatchers.IO

--- a/core/di/src/commonMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.kt
+++ b/core/di/src/commonMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.kt
@@ -2,15 +2,16 @@ package ir.amirroid.mafiauto.di.modules
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import org.koin.core.qualifier.qualifier
 import org.koin.dsl.module
 
 val IoDispatcher = qualifier("io")
 val MainDispatcher = qualifier("main")
 
+expect fun getIoDispatcher(): CoroutineDispatcher
+
 val dispatcherModule = module {
-    factory<CoroutineDispatcher>(IoDispatcher) { Dispatchers.IO }
+    factory<CoroutineDispatcher>(IoDispatcher) { getIoDispatcher() }
     factory<CoroutineDispatcher>(MainDispatcher) { Dispatchers.Main }
 
     factory { get<CoroutineDispatcher>(IoDispatcher) }

--- a/core/di/src/desktopMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.desktop.kt
+++ b/core/di/src/desktopMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.desktop.kt
@@ -1,0 +1,5 @@
+package ir.amirroid.mafiauto.di.modules
+
+import kotlinx.coroutines.Dispatchers
+
+actual fun getIoDispatcher() = Dispatchers.IO

--- a/core/di/src/iosMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.ios.kt
+++ b/core/di/src/iosMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.ios.kt
@@ -1,0 +1,6 @@
+package ir.amirroid.mafiauto.di.modules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+
+actual fun getIoDispatcher() = Dispatchers.IO

--- a/core/di/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.wasmJs.kt
+++ b/core/di/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/di/modules/DispatcherModule.wasmJs.kt
@@ -1,0 +1,5 @@
+package ir.amirroid.mafiauto.di.modules
+
+import kotlinx.coroutines.Dispatchers
+
+actual fun getIoDispatcher() = Dispatchers.Default

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -20,5 +20,8 @@ kotlin {
         desktopMain.dependencies {
             implementation(libs.ktor.client.okhttp)
         }
+        wasmJsMain.dependencies {
+            implementation(libs.ktor.client.js)
+        }
     }
 }

--- a/core/network/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/network/client/PlatformHttpClientProvider.wasmJs.kt
+++ b/core/network/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/network/client/PlatformHttpClientProvider.wasmJs.kt
@@ -1,0 +1,15 @@
+package ir.amirroid.mafiauto.network.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.js.Js
+
+
+class WebHttpClientProvider : PlatformHttpClientProvider {
+    override fun provide(): HttpClient {
+        return HttpClient(Js)
+    }
+}
+
+actual fun createHttpClientProvider(): PlatformHttpClientProvider {
+    return WebHttpClientProvider()
+}

--- a/core/preferences/build.gradle.kts
+++ b/core/preferences/build.gradle.kts
@@ -8,7 +8,18 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kstore)
+        }
+        androidMain.dependencies {
             implementation(libs.kstore.file)
+        }
+        iosMain.dependencies {
+            implementation(libs.kstore.file)
+        }
+        desktopMain.dependencies {
+            implementation(libs.kstore.file)
+        }
+        wasmJsMain.dependencies {
+            implementation(libs.kstore.storage)
         }
     }
 }

--- a/core/preferences/src/androidMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.android.kt
+++ b/core/preferences/src/androidMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.android.kt
@@ -1,8 +1,21 @@
 package ir.amirroid.mafiauot.preferences.di
 
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.file.extensions.storeOf
+import ir.amirroid.mafiauot.preferences.models.SettingsConfig
+import ir.amirroid.mafiauot.preferences.utils.SETTINGS_FILENAME
+import ir.amirroid.mafiauot.preferences.utils.SETTINGS_VERSION
+import kotlinx.io.files.Path
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 
 actual fun Module.configurePreferences() {
     factory(qualifier = StorePathQualifier) { androidContext().cacheDir.path }
+    single<KStore<SettingsConfig>> {
+        storeOf(
+            file = Path(get<String>(StorePathQualifier).plus("/$SETTINGS_FILENAME")),
+            version = SETTINGS_VERSION,
+            json = get()
+        )
+    }
 }

--- a/core/preferences/src/commonMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.kt
+++ b/core/preferences/src/commonMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.kt
@@ -1,12 +1,6 @@
 package ir.amirroid.mafiauot.preferences.di
 
-import io.github.xxfast.kstore.KStore
-import io.github.xxfast.kstore.file.extensions.storeOf
-import ir.amirroid.mafiauot.preferences.models.SettingsConfig
 import ir.amirroid.mafiauot.preferences.source.SettingsConfigPreferencesSource
-import ir.amirroid.mafiauot.preferences.utils.SETTINGS_FILENAME
-import ir.amirroid.mafiauot.preferences.utils.SETTINGS_VERSION
-import ir.amirroid.mafiauot.preferences.utils.toPath
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.qualifier.qualifier
@@ -18,12 +12,5 @@ expect fun Module.configurePreferences()
 
 val preferencesModule = module {
     configurePreferences()
-    single<KStore<SettingsConfig>> {
-        storeOf(
-            file = get<String>(StorePathQualifier).plus("/$SETTINGS_FILENAME").toPath(),
-            version = SETTINGS_VERSION,
-            json = get()
-        )
-    }
     factoryOf(::SettingsConfigPreferencesSource)
 }

--- a/core/preferences/src/commonMain/kotlin/ir/amirroid/mafiauot/preferences/utils/Extensions.kt
+++ b/core/preferences/src/commonMain/kotlin/ir/amirroid/mafiauot/preferences/utils/Extensions.kt
@@ -1,5 +1,0 @@
-package ir.amirroid.mafiauot.preferences.utils
-
-import kotlinx.io.files.Path
-
-internal fun String.toPath() = Path(this)

--- a/core/preferences/src/desktopMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.desktop.kt
+++ b/core/preferences/src/desktopMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.desktop.kt
@@ -1,6 +1,12 @@
 package ir.amirroid.mafiauot.preferences.di
 
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.file.extensions.storeOf
+import ir.amirroid.mafiauot.preferences.models.SettingsConfig
+import ir.amirroid.mafiauot.preferences.utils.SETTINGS_FILENAME
+import ir.amirroid.mafiauot.preferences.utils.SETTINGS_VERSION
 import ir.amirroid.mafiauto.common.app.utils.AppInfo
+import kotlinx.io.files.Path
 import org.koin.core.module.Module
 import java.io.File
 
@@ -9,5 +15,12 @@ actual fun Module.configurePreferences() {
         val baseCacheDir = File(System.getProperty("user.home"), ".${AppInfo.appName}/cache")
         baseCacheDir.mkdirs()
         baseCacheDir.absolutePath
+    }
+    single<KStore<SettingsConfig>> {
+        storeOf(
+            file = Path(get<String>(StorePathQualifier).plus("/$SETTINGS_FILENAME")),
+            version = SETTINGS_VERSION,
+            json = get()
+        )
     }
 }

--- a/core/preferences/src/iosMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.ios.kt
+++ b/core/preferences/src/iosMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.ios.kt
@@ -1,6 +1,12 @@
 package ir.amirroid.mafiauot.preferences.di
 
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.file.extensions.storeOf
+import ir.amirroid.mafiauot.preferences.models.SettingsConfig
+import ir.amirroid.mafiauot.preferences.utils.SETTINGS_FILENAME
+import ir.amirroid.mafiauot.preferences.utils.SETTINGS_VERSION
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.io.files.Path
 import org.koin.core.module.Module
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSFileManager
@@ -21,4 +27,11 @@ private fun getCachePath(): String {
 
 actual fun Module.configurePreferences() {
     factory(qualifier = StorePathQualifier) { getCachePath() }
+    single<KStore<SettingsConfig>> {
+        storeOf(
+            file = Path(get<String>(StorePathQualifier).plus("/$SETTINGS_FILENAME")),
+            version = SETTINGS_VERSION,
+            json = get()
+        )
+    }
 }

--- a/core/preferences/src/wasmJsMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.wasmJs.kt
+++ b/core/preferences/src/wasmJsMain/kotlin/ir/amirroid/mafiauot/preferences/di/PreferencesModule.wasmJs.kt
@@ -1,0 +1,10 @@
+package ir.amirroid.mafiauot.preferences.di
+
+import io.github.xxfast.kstore.KStore
+import io.github.xxfast.kstore.storage.storeOf
+import ir.amirroid.mafiauot.preferences.models.SettingsConfig
+import org.koin.core.module.Module
+
+actual fun Module.configurePreferences() {
+    single<KStore<SettingsConfig>> { storeOf(key = "settings") }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 kstore = { module = "io.github.xxfast:kstore", version.ref = "kstore" }
 kstore-file = { module = "io.github.xxfast:kstore-file", version.ref = "kstore" }
+kstore-storage = { module = "io.github.xxfast:kstore-storage", version.ref = "kstore" }
 confettikit = { module = "io.github.vinceglb:confettikit", version.ref = "confettikit" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
@@ -69,6 +70,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
 

--- a/shared/compat/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/compat/CompatModule.wasmJs.kt
+++ b/shared/compat/src/wasmJsMain/kotlin/ir/amirroid/mafiauto/compat/CompatModule.wasmJs.kt
@@ -1,0 +1,13 @@
+package ir.amirroid.mafiauto.compat
+
+import org.koin.dsl.module
+
+actual val compatModule = module {
+    factory<IconChangerCompat> {
+        object : IconChangerCompat {
+            override fun changeColor(colorName: String) {
+                // no-op
+            }
+        }
+    }
+}

--- a/webpack.config.d/sqljs-config.js
+++ b/webpack.config.d/sqljs-config.js
@@ -1,0 +1,16 @@
+config.resolve = {
+    fallback: {
+        fs: false,
+        path: false,
+        crypto: false,
+    }
+};
+
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+config.plugins.push(
+    new CopyWebpackPlugin({
+        patterns: [
+            '../../node_modules/sql.js/dist/sql-wasm.wasm'
+        ]
+    })
+);

--- a/webpack.config.d/sqljs-config.js
+++ b/webpack.config.d/sqljs-config.js
@@ -1,16 +1,17 @@
+// {project}/webpack.config.d/sqljs.js
 config.resolve = {
-    fallback: {
-        fs: false,
-        path: false,
-        crypto: false,
-    }
+  fallback: {
+    fs: false,
+    path: false,
+    crypto: false,
+  }
 };
 
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 config.plugins.push(
-    new CopyWebpackPlugin({
-        patterns: [
-            '../../node_modules/sql.js/dist/sql-wasm.wasm'
-        ]
-    })
+  new CopyWebpackPlugin({
+    patterns: [
+      '../../node_modules/sql.js/dist/sql-wasm.wasm'
+    ]
+  })
 );


### PR DESCRIPTION
This PR adds initial support for WebAssembly (WASM) and JS targets.

Currently includes:
- Setup for wasm-js target in the project
- Basic scaffolding for running on the browser
- Integration with Compose for Web

🚧 **Work in Progress:**  
Cannot be merged yet due to a known compatibility issue with `SQLDelight` in WASM environments.  
See: [cashapp/sqldelight#5848](https://github.com/cashapp/sqldelight/issues/5848) for more details.

Once the issue is resolved or a workaround is implemented, this branch can be finalized and merged.