### PR TITLE
build: disable Compose Compiler reports and metrics on CI

### DIFF
--- a/build-logic/convention/src/main/kotlin/ir/amirroid/mafiauto/convention/compose/ComposeCompilerConfiguration.kt
+++ b/build-logic/convention/src/main/kotlin/ir/amirroid/mafiauto/convention/compose/ComposeCompilerConfiguration.kt
@@ -4,6 +4,9 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeCompilerGradlePluginExtension
 
 fun Project.configureComposeCompiler(extension: ComposeCompilerGradlePluginExtension) {
+    val isCI = System.getenv("CI") == "true"
+    if (isCI) return
+
     extension.apply {
         reportsDestination.set(layout.buildDirectory.dir("compose_compiler"))
         metricsDestination.set(layout.buildDirectory.dir("compose_compiler"))


### PR DESCRIPTION
Disables the generation of Compose Compiler reports and metrics when running on a CI environment. This is achieved by checking for the `CI=true` environment variable.